### PR TITLE
Append existing regex list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 ## Pi-hole regex filters
 This is a custom (unofficial) regex.list file for use with Pi-hole version 4 or above.
 
-Please be aware that running the install or reset commands will remove any custom wildcards that you have specified to be blocked; so don't forget to make a note of these before continuing.
+Please be aware that the removal instructions will delete any custom wildcards that you have specified to be blocked; so don't forget to make a note of these before continuing.
 
 ### Installation Instructions
 1. Open up Putty (or your choice of SSH client) and login to your device
 2. Run the following commands:
 ```
-sudo curl https://raw.githubusercontent.com/mmotti/pihole-regex/master/regex.list -o /etc/pihole/regex.list
+wget -qO - https://raw.githubusercontent.com/mmotti/pihole-regex/master/regex.list | sudo tee -a /etc/pihole/regex.list
 sudo killall -SIGHUP pihole-FTL
 ```
 


### PR DESCRIPTION
By using `sudo tee -a`, you're able to elevate permissions and append to the existing `regex.list`, which ensures users get to keep their freshly migrated wildcards. :smile: 