### PR TITLE
Ignore error SC1117 in Shellcheck

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+# shellcheck disable=SC1117
 # Get existing Pi-Hole style wildcards
 # (^|\.)test\.com$
 pihole_wildcards="$(grep "^(\^|.*\$$" /etc/pihole/regex.list)"


### PR DESCRIPTION
This suppresses [SC1117](https://github.com/koalaman/shellcheck/wiki/SC1117) from showing up in Shellcheck. After analyzing the shell script, I see no other way to resolve the error. This is a trivial PR so whether or not you merge it is up to you.