### PR TITLE
blocks g00 subdomains used by Instart Logic to serve ads

### DIFF
--- a/regex.list
+++ b/regex.list
@@ -14,3 +14,4 @@
 ^stat(s|istics)?[0-9]*[-.]
 ^track(ers?|ing)?[0-9]*[-.]
 ^traff(ic)?[-.]
+.*\.g[0-9]+\..*


### PR DESCRIPTION
found [here](https://www.reddit.com/r/pihole/comments/b3fj60/regex_megathread/ej0aq7v/) been using for a few months with 0 issues