### PR TITLE
Blocking first-party tracker

### DIFF
--- a/regex.list
+++ b/regex.list
@@ -14,3 +14,5 @@
 ^stat(s|istics)?[0-9]*[-.]
 ^track(ers?|ing)?[0-9]*[-.]
 ^traff(ic)?[-.]
+\.eulerian.net$
+\.dnsdelegation.io$


### PR DESCRIPTION
Eulerian & Criteo start doing 1st-party tracking (for example `f7ds.liberation.fr`), relying on 1st-party subdomain pointing to `*.eulerian.net` or `*.dnsdelegation.io`
Only way to block this is with regex domain blocking, host file not possible… :sob: