### PR TITLE
Allow for multiple docker instances matching 'pihole'

### DIFF
--- a/install.py
+++ b/install.py
@@ -55,20 +55,19 @@ regexps_remove = set()
 print('[i] Checking for "pihole" docker container')
 
 # Initialise the docker variables
-docker_id = None
-docker_mnt = None
-docker_mnt_src = None
+docker_ids = []
+docker_mnt_srcs = []
 
 # Check to see whether the default "pihole" docker container is active
 try:
-    docker_id = subprocess.run(['docker', 'ps', '--filter', 'name=pihole', '-q'],
-                               stdout=subprocess.PIPE, universal_newlines=True).stdout.strip()
+    docker_ids = subprocess.run(['docker', 'ps', '--filter', 'name=pihole', '-q'],
+                               stdout=subprocess.PIPE, universal_newlines=True).stdout.splitlines(keepends=False)
 # Exception for if docker is not installed
 except FileNotFoundError:
     pass
 
 # If a pihole docker container was found, locate the first mount
-if docker_id:
+for docker_id in docker_ids:
     docker_mnt = subprocess.run(['docker', 'inspect', '--format', '{{ (json .Mounts) }}', docker_id],
                                 stdout=subprocess.PIPE, universal_newlines=True).stdout.strip()
     # Convert output to JSON and iterate through each dict
@@ -76,156 +75,162 @@ if docker_id:
         # If this mount's destination is /etc/pihole
         if json_dict['Destination'] == r'/etc/pihole':
             # Use the source path as our target
-            docker_mnt_src = json_dict['Source']
+            docker_mnt_srcs.append(json_dict['Source'])
             break
 
-    # If we successfully found the mount
-    if docker_mnt_src:
-        print('[i] Running in docker installation mode')
-        # Prepend restart commands
-        cmd_restart[0:0] = ['docker', 'exec', '-i', 'pihole']
+# If we successfully found the mount
+if docker_mnt_srcs:
+    print('[i] Running in docker installation mode')
+    # Prepend restart commands
+    cmd_restart[0:0] = ['docker', 'exec', '-i', 'pihole']
 else:
     print('[i] Running in physical installation mode ')
 
-# Set paths
-path_pihole = docker_mnt_src if docker_mnt_src else r'/etc/pihole'
-path_legacy_regex = os.path.join(path_pihole, 'regex.list')
-path_legacy_mmotti_regex = os.path.join(path_pihole, 'mmotti-regex.list')
-path_pihole_db = os.path.join(path_pihole, 'gravity.db')
+def update_regex(path_pihole):
+    # Set paths
+    path_legacy_regex = os.path.join(path_pihole, 'regex.list')
+    path_legacy_mmotti_regex = os.path.join(path_pihole, 'mmotti-regex.list')
+    path_pihole_db = os.path.join(path_pihole, 'gravity.db')
 
-# Check that pi-hole path exists
-if os.path.exists(path_pihole):
-    print('[i] Pi-hole path exists')
-else:
-    print(f'[e] {path_pihole} was not found')
-    exit(1)
-
-# Check for write access to /etc/pihole
-if os.access(path_pihole, os.X_OK | os.W_OK):
-    print(f'[i] Write access to {path_pihole} verified')
-else:
-    print(f'[e] Write access is not available for {path_pihole}. Please run as root or other privileged user')
-    exit(1)
-
-# Determine whether we are using DB or not
-if os.path.isfile(path_pihole_db) and os.path.getsize(path_pihole_db) > 0:
-    db_exists = True
-    print('[i] DB detected')
-else:
-    print('[i] Legacy regex.list detected')
-
-# Fetch the remote regexps
-str_regexps_remote = fetch_url(url_regexps_remote)
-
-# If regexps were fetched, remove any comments and add to set
-if str_regexps_remote:
-    regexps_remote.update(x for x in map(str.strip, str_regexps_remote.splitlines()) if x and x[:1] != '#')
-    print(f'[i] {len(regexps_remote)} regexps collected from {url_regexps_remote}')
-else:
-    print('[i] No remote regexps were found.')
-    exit(1)
-
-if db_exists:
-    # Create a DB connection
-    print(f'[i] Connecting to {path_pihole_db}')
-
-    try:
-        conn = sqlite3.connect(path_pihole_db)
-    except sqlite3.Error as e:
-        print(e)
+    # Check that pi-hole path exists
+    if os.path.exists(path_pihole):
+        print('[i] Pi-hole path exists')
+    else:
+        print(f'[e] {path_pihole} was not found')
         exit(1)
 
-    # Create a cursor object
-    c = conn.cursor()
+    # Check for write access to /etc/pihole
+    if os.access(path_pihole, os.X_OK | os.W_OK):
+        print(f'[i] Write access to {path_pihole} verified')
+    else:
+        print(f'[e] Write access is not available for {path_pihole}. Please run as root or other privileged user')
+        exit(1)
 
-    # Add / update remote regexps
-    print('[i] Adding / updating regexps in the DB')
+    # Determine whether we are using DB or not
+    if os.path.isfile(path_pihole_db) and os.path.getsize(path_pihole_db) > 0:
+        db_exists = True
+        print('[i] DB detected')
+    else:
+        print('[i] Legacy regex.list detected')
 
-    c.executemany('INSERT OR IGNORE INTO domainlist (type, domain, enabled, comment) '
-                  'VALUES (3, ?, 1, ?)',
-                  [(x, install_comment) for x in sorted(regexps_remote)])
-    c.executemany('UPDATE domainlist '
-                  'SET comment = ? WHERE domain in (?) AND comment != ?',
-                  [(install_comment, x, install_comment) for x in sorted(regexps_remote)])
+    # Fetch the remote regexps
+    str_regexps_remote = fetch_url(url_regexps_remote)
 
-    conn.commit()
+    # If regexps were fetched, remove any comments and add to set
+    if str_regexps_remote:
+        regexps_remote.update(x for x in map(str.strip, str_regexps_remote.splitlines()) if x and x[:1] != '#')
+        print(f'[i] {len(regexps_remote)} regexps collected from {url_regexps_remote}')
+    else:
+        print('[i] No remote regexps were found.')
+        exit(1)
 
-    # Fetch all current mmotti regexps in the local db
-    c.execute('SELECT domain FROM domainlist WHERE type = 3 AND comment = ?', (install_comment,))
-    regexps_mmotti_local_results = c.fetchall()
-    regexps_mmotti_local.update([x[0] for x in regexps_mmotti_local_results])
+    if db_exists:
+        # Create a DB connection
+        print(f'[i] Connecting to {path_pihole_db}')
 
-    # Remove any local entries that do not exist in the remote list
-    # (will only work for previous installs where we've set the comment field)
-    print('[i] Identifying obsolete regexps')
-    regexps_remove = regexps_mmotti_local.difference(regexps_remote)
+        try:
+            conn = sqlite3.connect(path_pihole_db)
+        except sqlite3.Error as e:
+            print(e)
+            exit(1)
 
-    if regexps_remove:
-        print('[i] Removing obsolete regexps')
-        c.executemany('DELETE FROM domainlist WHERE type = 3 AND domain in (?)', [(x,) for x in regexps_remove])
+        # Create a cursor object
+        c = conn.cursor()
+
+        # Add / update remote regexps
+        print('[i] Adding / updating regexps in the DB')
+
+        c.executemany('INSERT OR IGNORE INTO domainlist (type, domain, enabled, comment) '
+                      'VALUES (3, ?, 1, ?)',
+                      [(x, install_comment) for x in sorted(regexps_remote)])
+        c.executemany('UPDATE domainlist '
+                      'SET comment = ? WHERE domain in (?) AND comment != ?',
+                      [(install_comment, x, install_comment) for x in sorted(regexps_remote)])
+
         conn.commit()
 
-    # Delete mmotti-regex.list as if we've migrated to the db, it's no longer needed
-    if os.path.exists(path_legacy_mmotti_regex):
-        os.remove(path_legacy_mmotti_regex)
+        # Fetch all current mmotti regexps in the local db
+        c.execute('SELECT domain FROM domainlist WHERE type = 3 AND comment = ?', (install_comment,))
+        regexps_mmotti_local_results = c.fetchall()
+        regexps_mmotti_local.update([x[0] for x in regexps_mmotti_local_results])
 
-    print('[i] Restarting Pi-hole')
-    subprocess.run(cmd_restart, stdout=subprocess.DEVNULL)
+        # Remove any local entries that do not exist in the remote list
+        # (will only work for previous installs where we've set the comment field)
+        print('[i] Identifying obsolete regexps')
+        regexps_remove = regexps_mmotti_local.difference(regexps_remote)
 
-    # Prepare final result
-    print('[i] Done - Please see your installed regexps below\n')
+        if regexps_remove:
+            print('[i] Removing obsolete regexps')
+            c.executemany('DELETE FROM domainlist WHERE type = 3 AND domain in (?)', [(x,) for x in regexps_remove])
+            conn.commit()
 
-    c.execute('Select domain FROM domainlist WHERE type = 3')
-    final_results = c.fetchall()
-    regexps_local.update(x[0] for x in final_results)
+        # Delete mmotti-regex.list as if we've migrated to the db, it's no longer needed
+        if os.path.exists(path_legacy_mmotti_regex):
+            os.remove(path_legacy_mmotti_regex)
 
-    print(*sorted(regexps_local), sep='\n')
+        print('[i] Restarting Pi-hole')
+        subprocess.run(cmd_restart, stdout=subprocess.DEVNULL)
 
-    conn.close()
+        # Prepare final result
+        print('[i] Done - Please see your installed regexps below\n')
 
+        c.execute('Select domain FROM domainlist WHERE type = 3')
+        final_results = c.fetchall()
+        regexps_local.update(x[0] for x in final_results)
+
+        print(*sorted(regexps_local), sep='\n')
+
+        conn.close()
+
+    else:
+        # If regex.list exists and is not empty
+        # Read it and add to a set
+        if os.path.isfile(path_legacy_regex) and os.path.getsize(path_legacy_regex) > 0:
+            print('[i] Collecting existing entries from regex.list')
+            with open(path_legacy_regex, 'r') as fRead:
+                regexps_local.update(x for x in map(str.strip, fRead) if x and x[:1] != '#')
+
+        # If the local regexp set is not empty
+        if regexps_local:
+            print(f'[i] {len(regexps_local)} existing regexps identified')
+            # If we have a record of a previous legacy install
+            if os.path.isfile(path_legacy_mmotti_regex) and os.path.getsize(path_legacy_mmotti_regex) > 0:
+                print('[i] Existing mmotti-regex install identified')
+                # Read the previously installed regexps to a set
+                with open(path_legacy_mmotti_regex, 'r') as fOpen:
+                    regexps_legacy_mmotti.update(x for x in map(str.strip, fOpen) if x and x[:1] != '#')
+
+                    if regexps_legacy_mmotti:
+                        print('[i] Removing previously installed regexps')
+                        regexps_local.difference_update(regexps_legacy_mmotti)
+
+        # Add remote regexps to local regexps
+        print(f'[i] Syncing with {url_regexps_remote}')
+        regexps_local.update(regexps_remote)
+
+        # Output to regex.list
+        print(f'[i] Outputting {len(regexps_local)} regexps to {path_legacy_regex}')
+        with open(path_legacy_regex, 'w') as fWrite:
+            for line in sorted(regexps_local):
+                fWrite.write(f'{line}\n')
+
+        # Output mmotti remote regexps to mmotti-regex.list
+        # for future install / uninstall
+        with open(path_legacy_mmotti_regex, 'w') as fWrite:
+            for line in sorted(regexps_remote):
+                fWrite.write(f'{line}\n')
+
+        print('[i] Restarting Pi-hole')
+        subprocess.run(cmd_restart, stdout=subprocess.DEVNULL)
+
+        # Prepare final result
+        print('[i] Done - Please see your installed regexps below\n')
+        with open(path_legacy_regex, 'r') as fOpen:
+            for line in fOpen:
+                print(line, end='')
+
+if docker_mnt_srcs:
+    for docker_mnt_src in docker_mnt_srcs:
+        update_regex(docker_mnt_src)
 else:
-    # If regex.list exists and is not empty
-    # Read it and add to a set
-    if os.path.isfile(path_legacy_regex) and os.path.getsize(path_legacy_regex) > 0:
-        print('[i] Collecting existing entries from regex.list')
-        with open(path_legacy_regex, 'r') as fRead:
-            regexps_local.update(x for x in map(str.strip, fRead) if x and x[:1] != '#')
-
-    # If the local regexp set is not empty
-    if regexps_local:
-        print(f'[i] {len(regexps_local)} existing regexps identified')
-        # If we have a record of a previous legacy install
-        if os.path.isfile(path_legacy_mmotti_regex) and os.path.getsize(path_legacy_mmotti_regex) > 0:
-            print('[i] Existing mmotti-regex install identified')
-            # Read the previously installed regexps to a set
-            with open(path_legacy_mmotti_regex, 'r') as fOpen:
-                regexps_legacy_mmotti.update(x for x in map(str.strip, fOpen) if x and x[:1] != '#')
-
-                if regexps_legacy_mmotti:
-                    print('[i] Removing previously installed regexps')
-                    regexps_local.difference_update(regexps_legacy_mmotti)
-
-    # Add remote regexps to local regexps
-    print(f'[i] Syncing with {url_regexps_remote}')
-    regexps_local.update(regexps_remote)
-
-    # Output to regex.list
-    print(f'[i] Outputting {len(regexps_local)} regexps to {path_legacy_regex}')
-    with open(path_legacy_regex, 'w') as fWrite:
-        for line in sorted(regexps_local):
-            fWrite.write(f'{line}\n')
-
-    # Output mmotti remote regexps to mmotti-regex.list
-    # for future install / uninstall
-    with open(path_legacy_mmotti_regex, 'w') as fWrite:
-        for line in sorted(regexps_remote):
-            fWrite.write(f'{line}\n')
-
-    print('[i] Restarting Pi-hole')
-    subprocess.run(cmd_restart, stdout=subprocess.DEVNULL)
-
-    # Prepare final result
-    print('[i] Done - Please see your installed regexps below\n')
-    with open(path_legacy_regex, 'r') as fOpen:
-        for line in fOpen:
-            print(line, end='')
+    update_regex('/etc/pihole')

--- a/install.py
+++ b/install.py
@@ -78,14 +78,6 @@ for docker_id in docker_ids:
             docker_mnt_srcs.append(json_dict['Source'])
             break
 
-# If we successfully found the mount
-if docker_mnt_srcs:
-    print('[i] Running in docker installation mode')
-    # Prepend restart commands
-    cmd_restart[0:0] = ['docker', 'exec', '-i', 'pihole']
-else:
-    print('[i] Running in physical installation mode ')
-
 def update_regex(path_pihole):
     # Set paths
     path_legacy_regex = os.path.join(path_pihole, 'regex.list')
@@ -230,7 +222,11 @@ def update_regex(path_pihole):
                 print(line, end='')
 
 if docker_mnt_srcs:
+    print('[i] Running in docker installation mode')
+    # Prepend restart commands
+    cmd_restart[0:0] = ['docker', 'exec', '-i', 'pihole']
     for docker_mnt_src in docker_mnt_srcs:
         update_regex(docker_mnt_src)
 else:
+    print('[i] Running in physical installation mode ')
     update_regex('/etc/pihole')


### PR DESCRIPTION
I run two pihole docker instances. The install script fails in this case because `docker ps --filter name=pihole` can match and return multiple lines. This patch does the right thing in that case: namely, applies the regex update to all of the running instances.
