### PR TITLE
Whitelist false positives in Microsoft Azure Portal

### DIFF
--- a/whitelist.list
+++ b/whitelist.list
@@ -7,7 +7,9 @@
 
 anti-ad.net
 iij.ad.jp
+main.iam.ad.ext.azure.com
 stats.foldingathome.org
 stats.stackexchange.com
+support.iam.ad.azure.com
 www.ad.nl
 www.iij.ad.jp


### PR DESCRIPTION
`ad` stands for "Active Directory" in the context of these urls which are necessary to use the Microsoft Azure Portal.