### PR TITLE
add Statistics Poland domain to the whitelist

### DIFF
--- a/whitelist.list
+++ b/whitelist.list
@@ -11,3 +11,4 @@ stats.foldingathome.org
 stats.stackexchange.com
 www.ad.nl
 www.iij.ad.jp
+stat.gov.pl


### PR DESCRIPTION
Hi!

I've noticed that the filters are catching false positive on [https://stat.gov.pl/](https://stat.gov.pl/) – the website of [Statistics Poland](https://en.wikipedia.org/wiki/Statistics_Poland)

Added it to the whitelist

Cheers